### PR TITLE
Make single and multi-file AD torrents known to SymlinkDownloader

### DIFF
--- a/server/RdtClient.Service/Helpers/DownloadHelper.cs
+++ b/server/RdtClient.Service/Helpers/DownloadHelper.cs
@@ -52,14 +52,6 @@ public static class DownloadHelper
         }
         else if (torrent.Files.Count == 1)
         {
-            // Debrid servers such as RealDebrid store single file torrents in a subfolder, but AllDebrid doesn't.
-            // We should replicate this behavior so that both folder structures are equal.
-            // See issue: https://github.com/rogerfar/rdt-client/issues/648
-            if (torrent.ClientKind != Torrent.TorrentClientKind.AllDebrid)
-            {
-                torrentPath = Path.Combine(downloadPath, directory);
-            }
-            
             var torrentFile = torrent.Files[0];
             var subPath = Path.GetDirectoryName(torrentFile.Path);
             
@@ -70,6 +62,14 @@ public static class DownloadHelper
                 subPath = subPath.Trim('/').Trim('\\');
 
                 torrentPath = Path.Combine(torrentPath, subPath);
+            }
+            
+            // Debrid servers such as RealDebrid store single file torrents in a subfolder, but AllDebrid doesn't.
+            // We should replicate this behavior so that both folder structures are equal.
+            // See issue: https://github.com/rogerfar/rdt-client/issues/648
+            if (torrent.ClientKind == Torrent.TorrentClientKind.AllDebrid)
+            {
+                return torrentFile.Path;
             }
         }
 

--- a/server/RdtClient.Service/Helpers/DownloadHelper.cs
+++ b/server/RdtClient.Service/Helpers/DownloadHelper.cs
@@ -29,12 +29,10 @@ public static class DownloadHelper
 
         fileName = FileHelper.RemoveInvalidFileNameChars(fileName);
 
-        var torrentPath = downloadPath;
+        var torrentPath = Path.Combine(downloadPath, directory);
 
         if (torrent.Files.Count > 1)
         {
-            torrentPath = Path.Combine(downloadPath, directory);
-
             var matchingTorrentFiles = torrent.Files.Where(m => m.Path.EndsWith(fileName)).Where(m => !String.IsNullOrWhiteSpace(m.Path)).ToList();
 
             if (matchingTorrentFiles.Count > 0)

--- a/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
@@ -73,6 +73,13 @@ public class SymlinkDownloader(String uri, String destinationPath, String path) 
 
             potentialFilePaths.Add(fileName);
             potentialFilePaths.Add(fileNameWithoutExtension);
+
+            var pathDirectoryName = Path.GetDirectoryName(path);
+            if (pathDirectoryName != null)
+            {
+                potentialFilePaths.Add(pathDirectoryName);
+            }
+
             // add an empty path so we can check for the new file in the base directory
             potentialFilePaths.Add("");
 

--- a/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
+++ b/server/RdtClient.Service/Services/TorrentClients/AllDebridTorrentClient.cs
@@ -64,7 +64,7 @@ public class AllDebridTorrentClient(ILogger<AllDebridTorrentClient> logger, IHtt
             Added = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(torrent.UploadDate),
             Files = torrent.Links.Select((m, i) => new TorrentClientFile
             {
-                Path = GetFiles(m.Files),
+                Path = torrent.Links.Count == 1 ? torrent.Filename : GetFiles(m.Files),
                 Bytes = m.Size,
                 Id = i,
                 Selected = true,


### PR DESCRIPTION
Firstly, by setting `Path` to `torrent.Filename` if `torrent.Links.Count == 1`, when `SymlinkDownloader` checks the `""` `potentialFilePath`, it will look for `/mnt-path/<torrent.Filename>` (which is where it will be).

Secondly, for the multi-file torrents, I've decided to just look directly at whatever directory the argument `path` specifies.

I'm a massive dotnet noob, so this may be non-idiomatic or approached wrong, but it does work for `TestMultiple.torrent` and `Name Mismatch (Single File)` (although rdt-client should probably error for this type of file since it's unreadable) .

I haven't implemented the erroring part when the single file is in a subdirectory - I'm not quite sure where should error. Since we know as soon as we get the `/magnets/status` response, we could error in `AllDebridTorrentClient.GetTorrents` - but we'd have to know that this was intended for the symlink downloader. Erroring in the `SymlinkDownloader` might make more sense?